### PR TITLE
Add help instructions for invalid command usage and solve the npm module issue

### DIFF
--- a/todo.js
+++ b/todo.js
@@ -43,7 +43,7 @@ switch(commands){
 */
 
 const chalk = require('chalk');
-console.log(chalk.blue('Hello world!'));
+
 
 const timestamp = require('time-stamp');
 

--- a/todo.js
+++ b/todo.js
@@ -103,5 +103,11 @@ switch(commands){
         */
     
     default:
-        console.log('invalid commands');
+        console.log(chalk.red('Invalid command.\n'));
+        console.log(chalk.yellow('Usage:'));
+        console.log('  node todo.js add "Your task here"');
+        console.log('  node todo.js list');
+        console.log('  node todo.js done <task number>');
+        console.log('  node todo.js delete <task number>');
+    break;
 }


### PR DESCRIPTION
- **Description:** 
Add command-line help output when no arguments are passed or when the command is invalid — this improves user experience and is easy to review in a commit; 
Install the correct version of chalk to ensure the file can normal work.
- **Related Issue:** Help user clearly know what they can do; Keep the file function.
- **Implementation Detail:** 
        console.log(chalk.yellow('Usage:'));
        console.log('  node todo.js add "Your task here"');
        console.log('  node todo.js list');
        console.log('  node todo.js done <task number>');
        console.log('  node todo.js delete <task number>');
        //
        node todo.list npm i chalk@4.1.2
- **Testing Step:** use console.log to test the output.
![image](https://github.com/user-attachments/assets/e712a133-402e-4753-918d-45764f859da4)
![image](https://github.com/user-attachments/assets/fdef5d56-e9f1-4ed5-8b09-a8511d406e2c)
